### PR TITLE
automatic detection of zero byte files during upload

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -612,9 +613,17 @@ func (f *Folder) WalkNodes(names ...string) (*Node, []*http.Response, error) {
 // Put stores the data read from in at path as name on the Amazon Cloud Drive.
 // Errors if the file already exists on the drive.
 func (s *NodesService) putOrOverwrite(in io.Reader, httpVerb, url, name, metadata string) (*File, *http.Response, error) {
+	var bodyReader io.Reader
+
 	bodyReader, bodyWriter := io.Pipe()
 	writer := multipart.NewWriter(bodyWriter)
 	contentType := writer.FormDataContentType()
+	contentLength := int64(-1)
+
+	buf := make([]byte, 1)
+	n, err := in.Read(buf)
+	isZeroLength := n == 0 && err == io.EOF
+	in = io.MultiReader(bytes.NewReader(buf), in)
 
 	errChan := make(chan error, 1)
 	go func() {
@@ -641,11 +650,21 @@ func (s *NodesService) putOrOverwrite(in io.Reader, httpVerb, url, name, metadat
 		errChan <- writer.Close()
 	}()
 
+	if isZeroLength {
+		buf, err := ioutil.ReadAll(bodyReader)
+		if err != nil {
+			return nil, nil, err
+		}
+		bodyReader = bytes.NewReader(buf)
+		contentLength = int64(len(buf))
+	}
+
 	req, err := s.client.NewContentRequest(httpVerb, url, bodyReader)
 	if err != nil {
 		return nil, nil, err
 	}
 
+	req.ContentLength = contentLength
 	req.Header.Add("Content-Type", contentType)
 
 	file := &File{&Node{service: s}}
@@ -654,63 +673,11 @@ func (s *NodesService) putOrOverwrite(in io.Reader, httpVerb, url, name, metadat
 		return nil, resp, err
 	}
 
-	err = <-errChan
-	if err != nil {
-		return nil, resp, err
-	}
-
 	return file, resp, err
 }
 
 // Put stores the data read from in at path as name on the Amazon Cloud Drive.
 // Errors if the file already exists on the drive.
-func (s *NodesService) putOrOverwriteSized(in io.Reader, fileSize int64, httpVerb, url, name, metadata string) (*File, *http.Response, error) {
-	var err error
-	bodyBuf := bytes.NewBufferString("")
-	bodyWriter := multipart.NewWriter(bodyBuf)
-
-	// use the bodyWriter to write the Part headers to the buffer
-	if metadata != "" {
-		err = bodyWriter.WriteField("metadata", string(metadata))
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	_, err = bodyWriter.CreateFormFile("content", name)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// need to know the boundary to properly close the part myself.
-	boundary := bodyWriter.Boundary()
-	closeBuf := bytes.NewBufferString(fmt.Sprintf("\r\n--%s--\r\n", boundary))
-
-	// use multi-reader to defer the reading of the file data
-	// until writing to the socket buffer.
-	requestReader := io.MultiReader(bodyBuf, in, closeBuf)
-
-	req, err := s.client.NewContentRequest(httpVerb, url, requestReader)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Set headers for multipart, and Content Length
-	req.Header.Add("Content-Type", "multipart/form-data; boundary="+boundary)
-	req.ContentLength = fileSize + int64(bodyBuf.Len()) + int64(closeBuf.Len())
-
-	file := &File{&Node{service: s}}
-	resp, err := s.client.Do(req, file)
-	if err != nil {
-		return nil, resp, err
-	}
-
-	return file, resp, err
-}
-
-// Put stores the data read from in at path as name on the Amazon Cloud Drive.
-// Errors if the file already exists on the drive.
-//
-// Can't put file with 0 length file (works sometimes)
 func (f *Folder) Put(in io.Reader, name string) (*File, *http.Response, error) {
 	metadata := createNode{
 		Name:    name,
@@ -725,8 +692,6 @@ func (f *Folder) Put(in io.Reader, name string) (*File, *http.Response, error) {
 }
 
 // Overwrite updates the file contents from in
-//
-// Can't overwrite with 0 length file (works sometimes)
 func (f *File) Overwrite(in io.Reader) (*File, *http.Response, error) {
 	url := fmt.Sprintf("nodes/%s/content", *f.Id)
 	return f.service.putOrOverwrite(in, "PUT", url, *f.Name, "")
@@ -734,23 +699,14 @@ func (f *File) Overwrite(in io.Reader) (*File, *http.Response, error) {
 
 // PutSized stores the data read from in at path as name on the Amazon
 // Cloud Drive.  Errors if the file already exists on the drive.
-func (f *Folder) PutSized(in io.Reader, size int64, name string) (*File, *http.Response, error) {
-	metadata := createNode{
-		Name:    name,
-		Kind:    "FILE",
-		Parents: []string{*f.Id},
-	}
-	metadataJSON, err := json.Marshal(&metadata)
-	if err != nil {
-		return nil, nil, err
-	}
-	return f.service.putOrOverwriteSized(in, size, "POST", "nodes?suppress=deduplication", name, string(metadataJSON))
+func (f *Folder) PutSized(in io.Reader, _size int64, name string) (*File, *http.Response, error) {
+	return f.Put(in, name)
 }
 
 // OverwriteSized updates the file contents from in
-func (f *File) OverwriteSized(in io.Reader, size int64) (*File, *http.Response, error) {
+func (f *File) OverwriteSized(in io.Reader, _size int64) (*File, *http.Response, error) {
 	url := fmt.Sprintf("nodes/%s/content", *f.Id)
-	return f.service.putOrOverwriteSized(in, size, "PUT", url, *f.Name, "")
+	return f.service.putOrOverwrite(in, "PUT", url, *f.Name, "")
 }
 
 // Upload stores the content of file at path as name on the Amazon Cloud Drive.

--- a/nodes.go
+++ b/nodes.go
@@ -6,6 +6,7 @@
 package acd
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"errors"
@@ -620,10 +621,9 @@ func (s *NodesService) putOrOverwrite(in io.Reader, httpVerb, url, name, metadat
 	contentType := writer.FormDataContentType()
 	contentLength := int64(-1)
 
-	buf := make([]byte, 1)
-	n, err := in.Read(buf)
-	isZeroLength := n == 0 && err == io.EOF
-	in = io.MultiReader(bytes.NewReader(buf), in)
+	bufIn := bufio.NewReader(in)
+	_, err := bufIn.Peek(1)
+	isZeroLength := err != nil
 
 	errChan := make(chan error, 1)
 	go func() {
@@ -643,7 +643,7 @@ func (s *NodesService) putOrOverwrite(in io.Reader, httpVerb, url, name, metadat
 			errChan <- err
 			return
 		}
-		if _, err := io.Copy(part, in); err != nil {
+		if _, err := io.Copy(part, bufIn); err != nil {
 			errChan <- err
 			return
 		}


### PR DESCRIPTION
This patch allows go-acd to upload zero byte files similarly to how it uploads other files. As I mentioned in https://github.com/ncw/rclone/issues/874#issuecomment-260209306, it's not possible to do this without any logic as AmazonDrive requires Content-Length to be set when uploading 0 byte files.

I suggest to review using `git diff --patience` for a more pleasant diff.

I kept the public "Sized" methods, although they are obsolete. I have a patch for rclone that stops calling them, so I can remove if you prefer.

The part to determine the content length for the 0 byte case is a bit ugly, but I have not found a better way to determine the size of a reader. And of course, go-acd's `Client.NewContentRequest` requires it to be an `io.Reader` again. This approach seemed to be the best of the bunch I tried, but I am open for suggestions.

Cheers
Stefan

PS: I tested this using an rclone mount, and roughly this:
```
echo -n '' > test && sleep 1 && [ -e test ] && [ ! -s test ] && echo "Zero Byte Test Success"
echo ' ' > test && sleep 1 && [ -e test ] && [ -s test ] && echo "Two Byte Test Success"
md5sum $(which rclone)
cp $(which rclone) test && sleep 1 && md5sum test
cat $(which rclone) > test && sleep 1 && md5sum test
```