### PR TITLE
Added Arch AMD64 & PPC64LE & Excluded the job ppc64le for go:1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 # enable container-based infrastructure by setting sudo to false
 sudo: false
 
+arch:
+ - amd64
+ - ppc64le
+
 language: go
 
 go:
@@ -10,6 +14,9 @@ go:
 matrix:
   allow_failures:
     - go: tip
+  exclude:
+    - arch: ppc64le
+      go: 1.4
 
 branches:
   only:


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and looks like its been successfully added and excluded the ppc64 job for the go version 1.4 because ppc64 supports the higher version. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/go-acd/builds/190241870

Please have a look.

Regards,
Manish